### PR TITLE
Ensure VCS entries are presented as attestations

### DIFF
--- a/attest/attest.go
+++ b/attest/attest.go
@@ -3,6 +3,7 @@ package attest
 import (
 	"fmt"
 
+	"github.com/docker/labs-brown-tape/attest/digest"
 	"github.com/docker/labs-brown-tape/attest/types"
 	"github.com/docker/labs-brown-tape/attest/vcs/git"
 )
@@ -11,23 +12,23 @@ var (
 	_ types.PathChecker = (*git.PathChecker)(nil)
 )
 
-func DetectVCS(path string) (types.PathChecker, *PathCheckerRegistry, error) {
-	for _, provider := range map[string]func(string) types.PathChecker{
+func DetectVCS(path string) (bool, *PathCheckerRegistry, error) {
+	for _, provider := range map[string]func(string, digest.SHA256) types.PathChecker{
 		// TODO: support other VCS providers
 		git.ProviderName: git.NewPathChecker,
 	} {
-		checker := provider(path)
+		checker := provider(path, "")
 		ok, err := checker.DetectRepo()
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to detect VCS: %w", err)
+			return false, nil, fmt.Errorf("unable to detect VCS: %w", err)
 		}
 		if ok {
 			registry := NewPathCheckerRegistry(path, provider)
-			if err := registry.Init(); err != nil {
-				return nil, nil, err
+			if err := registry.init(checker); err != nil {
+				return false, nil, err
 			}
-			return checker, registry, nil
+			return true, registry, nil
 		}
 	}
-	return nil, nil, nil
+	return false, nil, nil
 }

--- a/attest/manifest/images.go
+++ b/attest/manifest/images.go
@@ -1,12 +1,6 @@
 package manifest
 
 import (
-	"encoding/json"
-	"io"
-
-	toto "github.com/in-toto/in-toto-golang/in_toto"
-
-	"github.com/docker/labs-brown-tape/attest/digest"
 	attestTypes "github.com/docker/labs-brown-tape/attest/types"
 	manifestTypes "github.com/docker/labs-brown-tape/manifest/types"
 )
@@ -23,15 +17,11 @@ var (
 )
 
 type OriginalImageRef struct {
-	attestTypes.Subject `json:"subject"`
-
-	FoundImageReference ImageRefenceWithLocation `json:"foundImageReference"`
+	attestTypes.SingleSubjectStatement
 }
 
 type ResolvedImageRef struct {
-	attestTypes.Subject `json:"subject"`
-
-	ResolvedImageReference ImageRefenceWithLocation `json:"resolvedImageReference"`
+	attestTypes.SingleSubjectStatement
 }
 
 type ImageRefenceWithLocation struct {
@@ -40,13 +30,25 @@ type ImageRefenceWithLocation struct {
 	Column    int    `json:"column"`
 }
 
+// TODO:
+// - replaced
+// - related tags (just the tags)
+// - copy inline atteststations, and reference them
+// - copy sigstore attestations, and reference them
+
 func MakeOriginalImageRefStatements(images *manifestTypes.ImageList) attestTypes.Statements {
 	statements := attestTypes.Statements{}
 	forEachImage(images, func(subject attestTypes.Subject, ref ImageRefenceWithLocation) {
-		statements = append(statements, &OriginalImageRef{
-			Subject:             subject,
-			FoundImageReference: ref,
-		})
+		s := &OriginalImageRef{
+			attestTypes.MakeSingleSubjectStatement(
+				subject,
+				OriginalImageRefPredicateType,
+				struct {
+					FoundImageReference ImageRefenceWithLocation `json:"foundImageReference"`
+				}{ref},
+			),
+		}
+		statements = append(statements, s)
 	})
 	return statements
 }
@@ -55,35 +57,16 @@ func MakeResovedImageRefStatements(images *manifestTypes.ImageList) attestTypes.
 	statements := attestTypes.Statements{}
 	forEachImage(images, func(subject attestTypes.Subject, ref ImageRefenceWithLocation) {
 		statements = append(statements, &ResolvedImageRef{
-			Subject:                subject,
-			ResolvedImageReference: ref,
+			attestTypes.MakeSingleSubjectStatement(
+				subject,
+				ResolvedImageRefPredicateType,
+				struct {
+					ResolvedImageReference ImageRefenceWithLocation `json:"resolvedImageReference"`
+				}{ref},
+			),
 		})
 	})
 	return statements
-}
-
-func (OriginalImageRef) Type() string                                  { return OriginalImageRefPredicateType }
-func (ref OriginalImageRef) Data() interface{}                         { return ref }
-func (ref OriginalImageRef) GetSubjectName() string                    { return ref.Subject.Name }
-func (ref OriginalImageRef) GetSubjectDigest() digest.SHA256           { return ref.Subject.Digest }
-func (ref OriginalImageRef) ExportSubject() []toto.Subject             { return ref.Subject.Export() }
-func (ref OriginalImageRef) Export() toto.Statement                    { return export(ref) }
-func (ref OriginalImageRef) EncodeWith(e attestTypes.EncodeFunc) error { return e(ref.Export()) }
-
-func (ref OriginalImageRef) Encode(w io.Writer) error {
-	return ref.EncodeWith(json.NewEncoder(w).Encode)
-}
-
-func (ResolvedImageRef) Type() string                                  { return ResolvedImageRefPredicateType }
-func (ref ResolvedImageRef) Data() interface{}                         { return ref }
-func (ref ResolvedImageRef) GetSubjectName() string                    { return ref.Subject.Name }
-func (ref ResolvedImageRef) GetSubjectDigest() digest.SHA256           { return ref.Subject.Digest }
-func (ref ResolvedImageRef) ExportSubject() []toto.Subject             { return ref.Subject.Export() }
-func (ref ResolvedImageRef) Export() toto.Statement                    { return export(ref) }
-func (ref ResolvedImageRef) EncodeWith(e attestTypes.EncodeFunc) error { return e(ref.Export()) }
-
-func (ref ResolvedImageRef) Encode(w io.Writer) error {
-	return ref.EncodeWith(json.NewEncoder(w).Encode)
 }
 
 func forEachImage(images *manifestTypes.ImageList, do func(attestTypes.Subject, ImageRefenceWithLocation)) {
@@ -106,16 +89,5 @@ func forEachImage(images *manifestTypes.ImageList, do func(attestTypes.Subject, 
 				},
 			)
 		}
-	}
-}
-
-func export(ref attestTypes.Statement) toto.Statement {
-	return toto.Statement{
-		StatementHeader: toto.StatementHeader{
-			Type:          toto.StatementInTotoV01,
-			PredicateType: ref.Type(),
-			Subject:       ref.ExportSubject(),
-		},
-		Predicate: ref,
 	}
 }

--- a/attest/manifest/manifest.go
+++ b/attest/manifest/manifest.go
@@ -1,0 +1,38 @@
+package manifest
+
+import (
+	"github.com/docker/labs-brown-tape/attest/types"
+)
+
+const (
+	ManifestDirPredicateType = "docker.com/tape/ManifestDir/v0.1"
+)
+
+var (
+	_ types.Statement = (*DirContents)(nil)
+)
+
+type DirContents struct{ types.MultiSubjectStatement }
+
+type SourceDirectory struct {
+	Path string `json:"path"`
+
+	VCSEntries *types.PathCheckSummaryCollection `json:"vcsEntries"`
+}
+
+func MakeDirContentsStatement(dir string, entries *types.PathCheckSummaryCollection) types.Statement {
+	return &DirContents{
+		types.MakeMultiSubjectStatement(
+			entries.Subject(),
+			ManifestDirPredicateType,
+			struct {
+				ContainedInDirectory SourceDirectory `json:"containedInDirectory"`
+			}{
+				SourceDirectory{
+					Path:       dir,
+					VCSEntries: entries,
+				},
+			},
+		),
+	}
+}

--- a/attest/registry.go
+++ b/attest/registry.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/labs-brown-tape/attest/digest"
+	"github.com/docker/labs-brown-tape/attest/manifest"
 	"github.com/docker/labs-brown-tape/attest/types"
 )
 
@@ -16,94 +17,138 @@ type PathCheckerRegistryKey struct {
 }
 
 type PathCheckerRegistry struct {
-	newPathChecker func(string) types.PathChecker
-	baseDir        string
-	registry       map[PathCheckerRegistryKey]types.PathChecker
-	statements     map[PathCheckerRegistryKey]types.Statements
+	newPathChecker func(string, digest.SHA256) types.PathChecker
+
+	registry   map[PathCheckerRegistryKey]types.PathChecker
+	statements types.Statements
+
+	baseDir
 }
 
-func NewPathCheckerRegistry(dir string, newPathChecker func(string) types.PathChecker) *PathCheckerRegistry {
+type baseDir struct {
+	pathChecker   types.PathChecker
+	cachedSummary types.PathCheckSummary
+
+	fromWorkDir, fromRepoRoot string
+}
+
+func NewPathCheckerRegistry(dir string, newPathChecker func(string, digest.SHA256) types.PathChecker) *PathCheckerRegistry {
 	return &PathCheckerRegistry{
+		baseDir:        baseDir{fromWorkDir: dir},
 		newPathChecker: newPathChecker,
-		baseDir:        dir,
 		registry:       map[PathCheckerRegistryKey]types.PathChecker{},
-		statements:     map[PathCheckerRegistryKey]types.Statements{},
+		statements:     types.Statements{},
 	}
 }
 
-func (r *PathCheckerRegistry) Init() error {
-	dir := r.baseDir
-	if dir == "" {
-		dir = "."
+func (r *PathCheckerRegistry) BaseDirSummary() types.PathCheckSummary {
+	return r.baseDir.cachedSummary
+}
+
+func (r *PathCheckerRegistry) init(baseDirChecker types.PathChecker) error {
+	summary, err := baseDirChecker.MakeSummary()
+	if err != nil {
+		return fmt.Errorf("unable to make summary for %#v: %w", r.dir(), err)
 	}
-	if err := r.Register(dir, ""); err != nil {
-		return fmt.Errorf("unable to initialise path checker registry: %w", err)
+	r.baseDir = baseDir{
+		pathChecker:   baseDirChecker,
+		cachedSummary: summary,
+		fromRepoRoot:  summary.Common().Path,
+		fromWorkDir:   r.fromWorkDir,
 	}
 	return nil
 }
 
-func (r *PathCheckerRegistry) makeKey(path string, digest digest.SHA256) PathCheckerRegistryKey {
-	if r.baseDir != "" && r.baseDir != path {
-		path = filepath.Join(r.baseDir, path)
-	}
-	return PathCheckerRegistryKey{Path: path, Digest: digest}
-}
-
 func (r *PathCheckerRegistry) Register(path string, digest digest.SHA256) error {
-	key := r.makeKey(path, digest)
+	key := r.makeKey(r.pathFromRepoRoot(path), digest)
 	if _, ok := r.registry[key]; ok {
 		return fmt.Errorf("path checker already reigstered for %#v", key)
 	}
-	r.registry[key] = r.newPathChecker(key.Path)
+	r.registry[key] = r.newPathChecker(r.pathFromWorkDir(path), digest)
 	return nil
 }
 
 func (r *PathCheckerRegistry) AssociateStatements(statements ...types.Statement) error {
-	for _, statement := range statements {
-		key := r.makeKey(statement.GetSubjectName(), statement.GetSubjectDigest())
-		if _, ok := r.registry[key]; !ok {
-			return fmt.Errorf("path checker not reigstered for %#v", key)
+	for i := range statements {
+		if err := statements[i].SetSubjects(func(subject *types.Subject) error {
+			path := r.pathFromRepoRoot(subject.Name)
+			key := r.makeKey(path, subject.Digest)
+			if _, ok := r.registry[key]; !ok {
+				return fmt.Errorf("statement with subject %#v is not relevant (path resoved to %q)", subject, path)
+			}
+			subject.Name = path
+			return nil
+		}); err != nil {
+			return err
 		}
-		r.statements[key] = append(r.statements[key], statement)
+	}
+	r.statements = append(r.statements, statements...)
+	return nil
+}
+
+func (r *PathCheckerRegistry) MakePathCheckSummarySummaryCollection() (*types.PathCheckSummaryCollection, error) {
+	numEntries := len(r.registry) + 1
+	if numEntries == 0 {
+		return nil, nil
+	}
+	entries := make([]types.PathChecker, 1, numEntries)
+	entries[0] = r.baseDir.pathChecker
+	for key := range r.registry {
+		entries = append(entries, r.registry[key])
+	}
+	return types.MakePathCheckSummaryCollection(entries...)
+}
+
+func (r *PathCheckerRegistry) AssociateCoreStatements() error {
+	errFmt := "unable to associate core statements: %w"
+
+	entries, err := r.MakePathCheckSummarySummaryCollection()
+	if err != nil {
+		return fmt.Errorf(errFmt, err)
+	}
+
+	// this flow is different from AssociateCoreStatements, as path to
+	// files is always relative to repo root and statement.SetSubjects
+	// doesn't need to be called
+	statement := manifest.MakeDirContentsStatement(r.dir(), entries)
+	for _, subject := range statement.GetSubject() {
+		key := r.makeKey(subject.Name, subject.Digest)
+		if _, ok := r.registry[key]; !ok {
+			return fmt.Errorf("statement with subject %#v is not relevant", subject)
+		}
+	}
+	r.statements = append(r.statements, statement)
+
+	return nil
+}
+
+func (r *PathCheckerRegistry) EncodeAllAttestations(w io.Writer) error {
+	encoder := json.NewEncoder(w)
+	if err := r.statements.EncodeWith(encoder.Encode); err != nil {
+		return fmt.Errorf("unable to encode attestations: %w", err)
 	}
 	return nil
 }
 
-func (r *PathCheckerRegistry) EncodeAll(w io.Writer) error {
-	encoder := json.NewEncoder(w)
-	for key, checker := range r.registry {
-		doEncode := func(obj interface{}) error {
-			k := key.Path
-			if key.Digest != "" {
-				k += "@" + key.Digest.String()
-			}
-			switch obj := obj.(type) {
-			case types.Statements:
-				if err := obj.EncodeWith(encoder.Encode); err != nil {
-					return fmt.Errorf("unable to encode attestation for %q: %w", k, err)
-				}
-			case types.PathCheckSummary:
-				if err := encoder.Encode(map[string]interface{}{k: obj.Full()}); err != nil {
-					return fmt.Errorf("unable to encode VCS summary for %q: %w", k, err)
-				}
-			}
-			return nil
-		}
-		summary, err := checker.MakeSummary()
-		if err != nil {
-			return fmt.Errorf("unable to make summary for %v: %w", key, err)
-		}
-		if err := doEncode(summary.Full()); err != nil {
-			return err
-		}
-		statements, ok := r.statements[key]
-		if !ok {
-			continue
-		}
-		if err := doEncode(statements); err != nil {
-			return err
-		}
+func (r *PathCheckerRegistry) dir() string {
+	switch {
+	case r.baseDir.fromRepoRoot != "":
+		return r.baseDir.fromRepoRoot
+	case r.baseDir.fromWorkDir != "":
+		return r.baseDir.fromWorkDir
+	default:
+		return "."
 	}
+}
 
-	return nil
+func (r *PathCheckerRegistry) pathFromRepoRoot(path string) string {
+	return filepath.Join(r.fromRepoRoot, path)
+}
+
+func (r *PathCheckerRegistry) pathFromWorkDir(path string) string {
+	return filepath.Join(r.fromWorkDir, path)
+}
+
+func (r *PathCheckerRegistry) makeKey(path string, digest digest.SHA256) PathCheckerRegistryKey {
+	return PathCheckerRegistryKey{Path: path, Digest: digest}
 }

--- a/attest/types/types.go
+++ b/attest/types/types.go
@@ -10,29 +10,44 @@ import (
 	toto "github.com/in-toto/in-toto-golang/in_toto"
 )
 
-type PathChecker interface {
-	ProviderName() string
-	DetectRepo() (bool, error)
-	Check() (bool, bool, error)
-	MakeSummary() (PathCheckSummary, error)
-}
-
 type (
+	PathCheckerRegistryKey struct {
+		Path   string
+		Digest digest.SHA256
+	}
+
+	PathChecker interface {
+		ProviderName() string
+		DetectRepo() (bool, error)
+		Check() (bool, bool, error)
+		MakeSummary() (PathCheckSummary, error)
+	}
+
 	PathCheckSummaryCommon struct {
-		Unmodified bool   `json:"unmodified"`
-		Path       string `json:"path,omitempty"`
-		URI        string `json:"uri,omitempty"`
+		Unmodified bool          `json:"unmodified"`
+		Path       string        `json:"path,omitempty"`
+		URI        string        `json:"uri,omitempty"`
+		IsDir      bool          `json:"isDir,omitempty"`
+		Digest     digest.SHA256 `json:"digest,omitempty"`
+	}
+
+	PathCheckSummaryCollection struct {
+		Providers   []string             `json:"providers"`
+		EntryGroups [][]PathCheckSummary `json:"entryGroups"`
 	}
 
 	PathCheckSummary interface {
+		ProviderName() string
 		Common() PathCheckSummaryCommon
 		Full() interface{}
+		SameRepo(PathCheckSummary) bool
 	}
 
 	Subject struct {
 		Name   string        `json:"name"`
 		Digest digest.SHA256 `json:"digest"`
 	}
+	Subjects []Subject
 
 	Statements []Statement
 )
@@ -40,18 +55,51 @@ type (
 func (s PathCheckSummaryCommon) Common() PathCheckSummaryCommon { return s }
 
 type (
-	EncodeFunc func(any) error
-	Statement  interface {
-		Type() string
-		Data() interface{}
-		GetSubjectName() string
-		GetSubjectDigest() digest.SHA256
+	EncodeFunc          func(any) error
+	ExportableStatement interface {
+		GetType() string
+		GetPredicate() interface{}
 		ExportSubject() []toto.Subject
 		Export() toto.Statement
+	}
+	Statement interface {
+		ExportableStatement
+
+		GetSubject() Subjects
 		Encode(io.Writer) error
 		EncodeWith(EncodeFunc) error
+		SetSubjects(func(*Subject) error) error
+	}
+
+	Predicate struct {
+		Type      string      `json:"predicateType"`
+		Predicate interface{} `json:"predicate"`
+	}
+	SingleSubjectStatement struct {
+		Subject Subject `json:"subject"`
+		Predicate
+	}
+	MultiSubjectStatement struct {
+		Subjects Subjects `json:"subject"`
+		Predicate
 	}
 )
+
+var (
+	_ Statement = (*SingleSubjectStatement)(nil)
+	_ Statement = (*MultiSubjectStatement)(nil)
+)
+
+func Export(s ExportableStatement) toto.Statement {
+	return toto.Statement{
+		StatementHeader: toto.StatementHeader{
+			Type:          toto.StatementInTotoV01,
+			PredicateType: s.GetType(),
+			Subject:       s.ExportSubject(),
+		},
+		Predicate: s.GetPredicate(),
+	}
+}
 
 func (s Statements) Export() []toto.Statement {
 	statements := make([]toto.Statement, len(s))
@@ -108,5 +156,137 @@ func (s *Subject) UnmarshalJSON(data []byte) error {
 		Digest: digest.SHA256(digestValue),
 	}
 
+	return nil
+}
+
+func MakeSubjects(subjects ...Subject) Subjects { return append(Subjects{}, subjects...) }
+
+func (s Subjects) Export() []toto.Subject {
+	subjects := make([]toto.Subject, 0, len(s))
+	for i := range s {
+		subjects = append(subjects, s[i].Export()...)
+	}
+	return subjects
+}
+
+func (s Subjects) MarshalJSON() ([]byte, error)     { return json.Marshal(s.Export()) }
+func (s *Subjects) UnmarshalJSON(data []byte) error { return json.Unmarshal(data, s) }
+
+func MakePathCheckSummaryCollection(entries ...PathChecker) (*PathCheckSummaryCollection, error) {
+	numEntries := len(entries)
+	if numEntries == 0 {
+		return nil, nil
+	}
+	summaries := make([]PathCheckSummary, numEntries)
+	for i := range entries {
+		if entries[i] == nil {
+			return nil, fmt.Errorf("nil entry at index %d", i)
+		}
+		summary, err := entries[i].MakeSummary()
+		if err != nil {
+			return nil, err
+		}
+		summaries[i] = summary
+	}
+
+	groups := [][]PathCheckSummary{}
+	for s := range summaries {
+		matched := false
+		for g := range groups {
+			if len(groups[g]) == 0 {
+				return nil, fmt.Errorf("empty group at index %d", g)
+			}
+			if summaries[s].SameRepo(groups[g][0]) {
+				groups[g] = append(groups[g], summaries[s])
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			groups = append(groups, []PathCheckSummary{summaries[s]})
+		}
+	}
+
+	providers := map[string]struct{}{}
+	for _, entry := range groups {
+		providers[entry[0].ProviderName()] = struct{}{}
+	}
+
+	collection := &PathCheckSummaryCollection{
+		Providers:   make([]string, 0, len(providers)),
+		EntryGroups: groups,
+	}
+
+	for provider := range providers {
+		collection.Providers = append(collection.Providers, provider)
+	}
+	return collection, nil
+}
+
+func (c PathCheckSummaryCollection) Subject() Subjects {
+	subject := Subjects{}
+	for i := range c.EntryGroups {
+		for j := range c.EntryGroups[i] {
+			common := c.EntryGroups[i][j].Common()
+			if common.Digest == "" {
+				continue
+			}
+			subject = append(subject, MakeSubject(common.Path, common.Digest))
+		}
+	}
+	return subject
+}
+
+func (p Predicate) GetType() string           { return p.Type }
+func (p Predicate) GetPredicate() interface{} { return p.Predicate }
+
+func MakeSingleSubjectStatement(subject Subject, predicateType string, predicate interface{}) SingleSubjectStatement {
+	return SingleSubjectStatement{
+		Predicate: Predicate{
+			Type:      predicateType,
+			Predicate: predicate,
+		},
+		Subject: subject,
+	}
+}
+
+func (s SingleSubjectStatement) GetSubject() Subjects          { return MakeSubjects(s.Subject) }
+func (s SingleSubjectStatement) ExportSubject() []toto.Subject { return s.Subject.Export() }
+func (s SingleSubjectStatement) Export() toto.Statement        { return Export(s) }
+func (s SingleSubjectStatement) EncodeWith(e EncodeFunc) error { return e(s.Export()) }
+
+func (s SingleSubjectStatement) Encode(w io.Writer) error {
+	return s.EncodeWith(json.NewEncoder(w).Encode)
+}
+
+func (s *SingleSubjectStatement) SetSubjects(f func(subject *Subject) error) error {
+	return f(&s.Subject)
+}
+
+func MakeMultiSubjectStatement(subjects Subjects, predicateType string, predicate interface{}) MultiSubjectStatement {
+	return MultiSubjectStatement{
+		Predicate: Predicate{
+			Type:      predicateType,
+			Predicate: predicate,
+		},
+		Subjects: subjects,
+	}
+}
+
+func (s MultiSubjectStatement) GetSubject() Subjects          { return s.Subjects }
+func (s MultiSubjectStatement) ExportSubject() []toto.Subject { return s.Subjects.Export() }
+func (s MultiSubjectStatement) Export() toto.Statement        { return Export(s) }
+func (s MultiSubjectStatement) EncodeWith(e EncodeFunc) error { return e(s.Export()) }
+
+func (s MultiSubjectStatement) Encode(w io.Writer) error {
+	return s.EncodeWith(json.NewEncoder(w).Encode)
+}
+
+func (s *MultiSubjectStatement) SetSubjects(f func(subject *Subject) error) error {
+	for i := range s.Subjects {
+		if err := f(&s.Subjects[i]); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/attest/vcs/git/git_test.go
+++ b/attest/vcs/git/git_test.go
@@ -157,7 +157,7 @@ func TestGitProvider(t *testing.T) {
 
 			g := NewWithT(t)
 
-			checked, unmodified, err := NewPathChecker(tc.path).Check()
+			checked, unmodified, err := NewPathChecker(tc.path, "").Check()
 			g.Expect(err).To(tc.err)
 			g.Expect(checked).To(tc.checked)
 			g.Expect(unmodified).To(tc.unmodified)


### PR DESCRIPTION
- fix a number of bugs introduces in #3 and cleanup the code
- the attestations are using custom predicate type, as it appears much more meaningful than SLSA Provenance v1.0
  - it should be possible to generate proper SLSA attestations once there is machinery for all desired predicates as well as unit tests etc
  - that is primarily because SLSA spec is complex and it's not clear which way how it should map to what is known to tape